### PR TITLE
Add reproduce() function

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -51,6 +51,8 @@ if (NOT TORCH_MLIR_ENABLE_ONLY_MLIR_PYTHON_BINDINGS)
     ADD_TO_PARENT TorchMLIRPythonSources
     SOURCES
       __init__.py
+      repro.py
+      fx_minifier.py
       _dynamo_fx_importer.py
       compiler_utils.py
       dynamo.py

--- a/python/torch_mlir/compiler_utils.py
+++ b/python/torch_mlir/compiler_utils.py
@@ -120,6 +120,10 @@ def model_to_fxgraph(model, *model_args, dtype = None, **model_kwargs):
 
     fx_g = make_fx(
            model,
+           # sometimes there are decompositions for unsupported ops available.
+           # we don't currently know where these are listed, but just try adding
+           # the op here and see if the previously unsupported op is no longer
+           # produced (you should then see the decomposition in the IR)
            decomposition_table=get_decompositions(
             [
             torch.ops.aten.cumsum,

--- a/python/torch_mlir/compiler_utils.py
+++ b/python/torch_mlir/compiler_utils.py
@@ -122,6 +122,7 @@ def model_to_fxgraph(model, *model_args, dtype = None, **model_kwargs):
            model,
            decomposition_table=get_decompositions(
             [
+            torch.ops.aten.cumsum,
             torch.ops.aten.embedding_dense_backward,
             torch.ops.aten.native_layer_norm_backward,
             torch.ops.aten.slice_backward,

--- a/python/torch_mlir/fx_minifier.py
+++ b/python/torch_mlir/fx_minifier.py
@@ -1,0 +1,321 @@
+# Patched version of the same file in pytorch
+# Remove once https://github.com/pytorch/pytorch/issues/102169 is fixed
+# upstream.
+import torch.fx as fx
+import copy
+import torch
+import math
+import sys
+from typing import Callable, List
+from functools import wraps, partial
+from dataclasses import dataclass
+from torch._functorch.compile_utils import get_placeholders, get_outputs
+
+class ConcreteProp(torch.fx.Interpreter):
+    def run_node(self, n):
+        result = super().run_node(n)
+
+        found_tensor = False
+
+        def extract_tensor_meta(obj):
+            if isinstance(obj, torch.Tensor):
+                nonlocal found_tensor
+                found_tensor = True
+                return obj
+            else:
+                return obj
+
+        from torch.fx.node import map_aggregate
+        concrete_value = map_aggregate(result, extract_tensor_meta)
+        if found_tensor:
+            n.meta['concrete_value'] = concrete_value
+        return result
+
+    def propagate(self, *args):
+        return super().run(*args)
+
+
+# inplace modifies node/inps
+def _convert_node_to_placeholder(node, inps):
+    if node.op == 'output' or node.op == "placeholder":
+        return
+    node.op = 'placeholder'
+    node.args = ()
+    node.kwargs = {}
+    node.target = node.name
+    concrete_val = node.meta.get('concrete_value', None)
+    if isinstance(concrete_val, torch.Tensor):
+        inps.append(concrete_val)
+    else:
+        inps.append(torch.zeros(()))
+        for tuple_user in list(node.users):
+            _convert_node_to_placeholder(tuple_user, inps)
+
+def dump_state(fx_g, inps):
+    print(f"""
+# Working Repro with {len(fx_g.graph.nodes)} nodes
+inps = {[(i.shape, i.dtype, i.device.type) for i in inps]}
+inps = [torch.zeros(())] + [torch.ones(shape, dtype=dtype, device=device) for (shape, dtype, device) in inps]
+{fx_g.code}
+""")
+
+@dataclass
+class ReproState:
+    graph: fx.Graph
+    inps: List[torch.Tensor]
+
+def minifier(fail_f: fx.GraphModule, inps, module_fails, dump_state: Callable = dump_state):
+    """
+    Minimizes a FX graph with given inputs, such that the resulting FX graph still returns True for module_fails.
+
+    Does 2 main strategies:
+    1. Truncates suffix: Removes some suffix from the graph and sets a new output.
+    2. Delta Debugging: Tries replacing half of the graph with inputs. If fails,
+        tries replacing quarter of the graph, etc.
+
+    >>> # xdoctest: +SKIP(failing)
+    >>> failing_function = fx.symbolic_trace(f)
+    >>> minimize(failing_function, [torch.randn(5)], lambda fx_g, inps: fx_g(*inps))
+
+    note: module_fails returns True if it fails.
+    """
+    failing_graph = fail_f.graph
+    cur_size = len(failing_graph.nodes)
+
+    num_queries = 0
+
+    def deepcopy_fx_graph(fx_graph):
+        return fx.GraphModule(fail_f, copy.deepcopy(fx_graph)).graph
+
+
+    def graph_fails(graph, inps):
+        nonlocal num_queries
+        graph = copy.deepcopy(graph)
+        num_queries += 1
+        mod = fx.GraphModule(fail_f, graph)
+        mod.graph.lint()
+        return module_fails(mod, inps)
+
+    ConcreteProp(fail_f).propagate(*inps)
+    if not graph_fails(failing_graph, inps):
+        raise RuntimeError("Input graph did not fail the tester")
+    print(f"Started off with {cur_size} nodes", file=sys.stderr)
+
+    def _register_strategy(strategy: Callable, name: str):
+        @wraps(strategy)
+        def new_func(old_state: ReproState, granularity=1):
+            print(file=sys.stderr)
+            print(
+                f"Strategy: {name} (G: {granularity}) "
+                f"({len(old_state.graph.nodes)} nodes, {len(old_state.inps)} inputs)",
+                file=sys.stderr
+            )
+            new_state = strategy(deepcopy_fx_graph(old_state.graph), list(old_state.inps), granularity)
+            if new_state is not None:
+                new_nodes = len(new_state.graph.nodes)
+                old_nodes = len(old_state.graph.nodes)
+                new_inps = len(new_state.inps)
+                old_inps = len(old_state.inps)
+                new_outs = len(get_outputs(new_state.graph))
+                old_outs = len(get_outputs(old_state.graph))
+                progress_made = False
+                if new_nodes < old_nodes:
+                    progress_made = True
+                    print(f"SUCCESS: Went from {old_nodes} to {new_nodes} nodes", file=sys.stderr)
+                if new_inps > old_inps:
+                    progress_made = True
+                    print(f"SUCCESS: Went from {old_inps} to {new_inps} inputs", file=sys.stderr)
+                if new_outs < old_outs:
+                    progress_made = True
+                    print(f"SUCCESS: Went from {old_outs} to {new_outs} outputs", file=sys.stderr)
+
+                if not progress_made:
+                    raise RuntimeError("Success raised but no progress made?")
+
+                if not graph_fails(new_state.graph, new_state.inps):
+                    print("WARNING: Something went wrong, not applying this minification", file=sys.stderr)
+                    return None
+                return new_state
+            else:
+                print(f"FAIL: {name}", file=sys.stderr)
+            return None
+
+        return new_func
+
+    def register_strategy(name: str):
+        return partial(_register_strategy, name=name)
+
+    @register_strategy("Truncate suffix")
+    def remove_suffix(cur_graph, cur_inps, granularity):
+        tested = set()
+        new_graph = fx.Graph()
+        env = {}
+        for idx, node in enumerate(cur_graph.nodes):
+            new_node = new_graph.node_copy(node, lambda x: env[x])
+            if node.op not in ['placeholder', 'output']:
+                # If idx is divisible by (granularity * 2), it would have been checked already.
+                if idx % granularity == 0 and (idx % (granularity * 2) != 0) and idx not in tested:
+                    output_node = new_graph.output(new_node)
+                    if len(new_graph.nodes) < len(cur_graph.nodes) and graph_fails(new_graph, cur_inps):
+                        return ReproState(new_graph, cur_inps)
+                    else:
+                        tested.add(idx)
+                        new_graph.erase_node(output_node)
+            env[node] = new_node
+        return None
+
+    @register_strategy("Remove outputs")
+    def remove_outputs(cur_graph, cur_inps, granularity):
+        granularity = max(1, granularity // 2)
+        for idx, node in enumerate(cur_graph.nodes):
+            node.idx = idx
+            if node.op == 'output':
+                output = node
+                break
+
+        if isinstance(output.args[0], fx.Node):
+            # Only one output, nothing to reduce
+            return None
+        
+        output_args = sorted(output.args[0], key=lambda x: x.idx if isinstance(x, fx.Node) else int(1e9))
+        if len(output_args) == 1:
+            return None
+
+        for idx in range(0, len(output_args), granularity):
+            output.args = (output_args[:idx] + output_args[idx + granularity:],)
+            if len(output.args[0]) == 1:
+                output.args = (output.args[0][0],)
+            if graph_fails(cur_graph, cur_inps):
+                return ReproState(cur_graph, cur_inps)
+        return None
+
+    def remove_unused_inputs_unchecked(cur_state: ReproState):
+        cur_graph = cur_state.graph
+        cur_inps = cur_state.inps
+        ph_nodes = get_placeholders(cur_graph)
+        if len(ph_nodes) != len(cur_inps):
+            return None
+        assert len(ph_nodes) == len(cur_inps)
+
+        new_inps = []
+        for idx in range(len(ph_nodes)):
+            if len(ph_nodes[idx].users) == 0:
+                cur_graph.erase_node(ph_nodes[idx])
+            else:
+                new_inps.append(cur_inps[idx])
+        if len(new_inps) < len(cur_inps):
+            return ReproState(cur_graph, new_inps)
+        return None
+
+    def remove_unused_inputs_checked(cur_state: ReproState):
+        new_state = remove_unused_inputs_unchecked(cur_state)
+        if new_state is not None and graph_fails(new_state.graph, new_state.inps):
+            return new_state
+        return None
+
+    def _remove_unused_wrapper(cur_graph, cur_inps, granularity):
+        return remove_unused_inputs_checked(ReproState(cur_graph, cur_inps))
+
+    remove_unused_inputs = register_strategy("Remove unused inputs")(_remove_unused_wrapper)
+
+    @register_strategy("Eliminate dead code")
+    def eliminate_dead_code(cur_graph, cur_inps, granularity):
+        if cur_graph.eliminate_dead_code() and graph_fails(cur_graph, cur_inps):
+            return ReproState(cur_graph, cur_inps)
+        return None
+
+
+    def _consolidate_placeholders(cur_graph):
+        new_graph = fx.Graph()
+        env = {}
+        for node in cur_graph.nodes:
+            if node.op == 'placeholder':
+                new_node = new_graph.node_copy(node, lambda x: env[x])
+                env[node] = new_node
+
+        for node in cur_graph.nodes:
+            if node.op != 'placeholder':
+                new_node = new_graph.node_copy(node, lambda x: env[x])
+                env[node] = new_node
+        return new_graph
+
+    @register_strategy("Delta Debugging")
+    def delta_debugging(cur_graph: fx.Graph, cur_inps, granularity):
+        num_nodes = len(cur_graph.nodes)
+        for start_range in range(0, num_nodes, granularity):
+            is_removing = False
+            new_graph = deepcopy_fx_graph(cur_graph)
+            new_inps = cur_inps[:]
+            end_range = min(num_nodes, start_range + granularity)
+            for idx in range(start_range, end_range):
+                new_node = list(new_graph.nodes)[idx]
+                if new_node.op not in ['placeholder', 'output']:
+                    is_removing = True
+                    _convert_node_to_placeholder(new_node, new_inps)
+            if not is_removing:
+                continue
+            new_graph = _consolidate_placeholders(new_graph)
+            new_state = remove_unused_inputs_unchecked(ReproState(new_graph, new_inps))
+            if new_state is None:
+                new_state = ReproState(new_graph, new_inps)
+            if graph_fails(new_state.graph, new_state.inps):
+                return ReproState(new_state.graph, new_state.inps)
+
+        return None
+
+    failing_state = ReproState(failing_graph, inps)
+
+    def try_granularity(failing_state, granularity, use_non_granular):
+        print(f"Trying granularity {granularity}", file=sys.stderr)
+
+        strategies = []
+        num_nodes = len(failing_state.graph.nodes)
+        num_outputs = len(get_outputs(failing_state.graph))
+        if num_outputs > num_nodes // 2:
+            strategies += [remove_outputs]
+
+        if use_non_granular:
+            strategies += [eliminate_dead_code, remove_unused_inputs]
+
+        strategies += [remove_suffix, delta_debugging]
+
+        for strategy in strategies:
+            new_state = strategy(failing_state, granularity)
+            if new_state is not None:
+                return new_state
+        return None
+
+    while True:
+        dump_state(fx.GraphModule(fail_f, failing_state.graph), failing_state.inps)
+        granularity = int(2**(math.floor(math.log2(len(failing_state.graph.nodes)))))
+        new_state = try_granularity(failing_state, granularity, use_non_granular=True)
+        if new_state is not None:
+            failing_state = new_state
+            continue
+
+        granularity //= 2
+        has_progress = False
+        while granularity >= 1:
+            new_state = try_granularity(failing_state, granularity, use_non_granular=False)
+            if new_state is not None:
+                failing_state = new_state
+                has_progress = True
+                break
+            granularity //= 2
+        if has_progress:
+            continue
+
+        new_state = remove_outputs(failing_state, 1)
+        if new_state is not None:
+            failing_state = new_state
+            continue
+
+        break
+
+    if not graph_fails(failing_state.graph, failing_state.inps):
+        raise RuntimeError("Uh oh, something went wrong :( Final graph is not failing")
+
+    print(f"Made {num_queries} queries", file=sys.stderr)
+    failing_fx = fx.GraphModule(fail_f, failing_state.graph)
+    dump_state(failing_fx, failing_state.inps)
+    return failing_fx, failing_state.inps

--- a/python/torch_mlir/repro.py
+++ b/python/torch_mlir/repro.py
@@ -147,6 +147,7 @@ def _dump_reproducer(
         print(f"model.to({dtype})")
     print(f"inps = ({args})")
     print("out = model(*inps)")
+    print("# if you want to see the raw IR, you can print(torch_mlir.compile(model, inps, output_type='raw')")
     print(f"torch_mlir.compile(model, inps, output_type='{output_type}')")
     print("")
     print("---- SNIP ----")

--- a/python/torch_mlir/repro.py
+++ b/python/torch_mlir/repro.py
@@ -1,0 +1,197 @@
+"""
+Example:
+
+class Model(torch.nn.Module):
+        def forward(self, x):
+            x = x / 2.0
+            x = x + 2
+            x = x * 3
+            return x, x *5
+
+model = Model()
+inputs = (torch.ones(5, 4), )
+out = model(*inputs)
+
+reproduce(model, inputs, output_type="tosa", expected_error="failed to legalize")
+"""
+
+
+import contextlib
+import io
+import re
+from typing import List, Optional
+import torch
+import torch_mlir
+from torch.func import functionalize
+
+from torch_mlir.dynamo import make_simple_dynamo_backend
+from torch.fx.experimental.proxy_tensor import make_fx
+from torch._decomp import get_decompositions
+import torch.fx as fx
+
+from .compiler_utils import model_to_fxgraph
+
+# TODO: Switch to
+#   from functorch.compile import minifier
+# once the bug mentioned at the top of fx_minifier.py is fixed.
+from .fx_minifier import minifier
+
+
+class bcolors:
+    HEADER = "\033[95m"
+    OKBLUE = "\033[94m"
+    OKCYAN = "\033[96m"
+    OKGREEN = "\033[92m"
+    WARNING = "\033[93m"
+    FAIL = "\033[91m"
+    ENDC = "\033[0m"
+    BOLD = "\033[1m"
+    UNDERLINE = "\033[4m"
+
+
+_REs = {
+    r"RuntimeError:": r"RuntimeError: ",  # change so its kept
+    r"NameError:": r"NameError: ",
+    r"ImportError:": r"ImportError: ",
+    r"error: unknown:": r"error:",
+    r'error: ["<>a-zA-Z0-9._/-]+:[0-9]+:[0-9]+: (.*)': r"error: \1",
+    r".*unsupported by backend contract: tensor with unknown rank": "unsupported by backend contract: tensor with unknown rank",
+    r"torch.initialize.global_slots.*": r"torch.initialize.global_slots",
+    r'note: ["<>a-zA-Z0-9._/-]+:[0-9]+:[0-9]+: (.*)': r"note: \1",
+    r"note: unknown:": r"note:",
+    r"note: this is likely due to a missing transfer function in abstract_interp_lib_gen.py": "",
+    r"%[0-9]+": "%SSA",
+    r"\[[0-9]+(,[0-9]+)*\]": r"[dims]",
+}
+
+
+def _reduce_error_msg(msg):
+    lines = []
+    for line in msg.splitlines():
+        orgline = line
+        for regex, replacement in _REs.items():
+            line = re.sub(regex, replacement, line)
+        if line != "" and line != orgline:
+            lines.append(line)
+    if len(lines) == 0 or (len(lines) == 1 and lines[0] == ""):
+        return msg
+
+    return ", ".join(lines).strip()
+
+
+def _obtain_errror(fx_g: fx.GraphModule, inputs, output_type: str):
+    """
+    Runs the given module through torch_mlir and returns the error
+    message produced.
+    """
+    # The minifer introduces functions that return a tuple with a single
+    # tensor, which is not supported by torch_mlir.
+    # Wrap the module to unpack those outputs.
+    # torch.jit.script doesn't support *args and **kwargs as used in
+    # the wrapper, so we also need to apply make_fx to the wrapped
+    # model.
+    # Both of those are implemented by model_to_fxgraph().
+    # wrapped_g = model_to_fxgraph(model, *inputs)
+    _fix_single_output_tuple(fx_g)
+    with contextlib.redirect_stderr(io.StringIO()) as stderr:
+        try:
+            torch_mlir.compile(fx_g, inputs, output_type=output_type)
+            return ""
+        except Exception as e:
+            return str(e) + stderr.getvalue()
+
+
+def _fix_single_output_tuple(fx_g: fx.GraphModule):
+    """
+    torch_mlir.compile does not support modules that return a tuple of
+    a single tensor.
+    Change the module to return the tensor directly.
+    """
+    for idx, node in enumerate(fx_g.graph.nodes):
+        node.idx = idx
+        if node.op == "output":
+            if isinstance(node.args[0], fx.Node):
+                # Only one output, nothing to reduce
+                return None
+            if len(node.args[0]) == 1:
+                node.args = (node.args[0][0], node.args[1:])
+                fx_g.recompile()
+
+
+def _dump_reproducer(
+    fx_g: fx.GraphModule, inps: List[torch.Tensor], output_type: str, dtype
+):
+    _fix_single_output_tuple(fx_g)
+
+    print("---- SNIP ----")
+    print("import torch")
+    print("from torch import device") # Used inside fx_g.code
+    print("import torch_mlir")
+    print("")
+
+    print("class Model(torch.nn.Module):")
+    print("    ".join(fx_g.code.splitlines(True)))
+
+    print()
+    print("model = Model()")
+    args = ""
+    for inp in inps:
+        args += f"torch.ones({inp.shape}, dtype={inp.dtype}), "
+    if dtype is not None:
+        print(f"model.to({dtype})")
+    print(f"inps = ({args})")
+    print("out = model(*inps)")
+    print(f"torch_mlir.compile(model, inps, output_type='{output_type}')")
+    print("")
+    print("---- SNIP ----")
+
+
+def reproduce(
+    model: torch.nn.Module,
+    inputs,
+    output_type="torch",
+    dtype=None,
+    expected_error: Optional[str] = None,
+    verbose=False,
+):
+    """
+    Reduces the given model while ensuring that the error message seen by passing
+    the model through torch_mlir.compile() doesn't change.
+
+    When dtype is provided, calls model.to(dtype) as first step.
+
+    This function tries to automatically determine the essential parts of the
+    error message. You can also pass it explicitly via the expected_error
+    parameter.
+    """
+
+    fx_g = model_to_fxgraph(model, *inputs, dtype=dtype)
+
+    error = _obtain_errror(fx_g, inputs, output_type=output_type)
+    if error == "":
+        print("ERROR: torch_mlir.compile passes, nothing to reproduce")
+        return
+
+    print(f"Found error:\n{error}\nEND")
+
+    if expected_error is None:
+        expected_error = _reduce_error_msg(error)
+
+    print(
+        f"Looking for error message '{bcolors.WARNING}{expected_error}{bcolors.ENDC}'"
+    )
+
+    def module_fails(fx_g, inputs):
+        error = _obtain_errror(fx_g, inputs, output_type=output_type)
+        reduced_error = _reduce_error_msg(error)
+        fails = expected_error in reduced_error
+        if verbose:
+            print(
+                f"Testing graph\n{fx_g.code}\nERROR: {error}\nREDUCED_ERROR: {reduced_error}\nModule fails?: {fails}"
+            )
+        return fails
+
+    def show_reproducer(fx_g: fx.GraphModule, inps: List[torch.Tensor]):
+        _dump_reproducer(fx_g, inps, output_type, dtype)
+
+    minifier(fx_g, inputs, module_fails, dump_state=show_reproducer)


### PR DESCRIPTION
- Extract a common model_to_fxgraph() function
- Add a copy of https://github.com/pytorch/pytorch/blob/main/torch/_functorch/fx_minifier.py with fixes to how tuples are handled (will open an upstream PR)
- Add python/torch_mlir/repro.py to reduce torch models while keeping the same error out of `torch_mlir.compile(make_fx(model))`


Example output:
```
Strategy: Eliminate dead code (G: 2) (3 nodes, 1 inputs)
FAIL: Eliminate dead code

Strategy: Remove unused inputs (G: 2) (3 nodes, 1 inputs)
FAIL: Remove unused inputs

Strategy: Truncate suffix (G: 2) (3 nodes, 1 inputs)
FAIL: Truncate suffix

Strategy: Delta Debugging (G: 2) (3 nodes, 1 inputs)
FAIL: Delta Debugging
Trying granularity 1

Strategy: Truncate suffix (G: 1) (3 nodes, 1 inputs)
FAIL: Truncate suffix

Strategy: Delta Debugging (G: 1) (3 nodes, 1 inputs)
FAIL: Delta Debugging

Strategy: Remove outputs (G: 1) (3 nodes, 1 inputs)
FAIL: Remove outputs
Made 62 queries
---- SNIP ----
import torch
import torch_mlir

class Model(torch.nn.Module):

    
    
    def forward(self, _to_copy_1):
        cumsum = torch.ops.aten.cumsum(_to_copy_1, 1);  _to_copy_1 = None
        return cumsum
        

model = Model()
model.to(torch.bfloat16)
inps = (torch.ones(torch.Size([1, 12]), dtype=torch.int32), )
out = model(*inps)
torch_mlir.compile(model, inps, output_type='tosa')

---- SNIP ----
```