### PR TITLE
add decomposes to model to fxgraph

### DIFF
--- a/python/torch_mlir/compiler_utils.py
+++ b/python/torch_mlir/compiler_utils.py
@@ -122,6 +122,7 @@ def model_to_fxgraph(model, *model_args, dtype = None, **model_kwargs):
            model,
            decomposition_table=get_decompositions(
             [
+            torch.ops.aten.cumsum,
             torch.ops.aten.embedding_dense_backward,
             torch.ops.aten.native_layer_norm_backward,
             torch.ops.aten.slice_backward,


### PR DESCRIPTION
From sources of `failed to legalize operation 'torch.constant.int'`
- torch.ops.aten.cumsum

With the first commit `python ./model.py --fxtype tosa --modeltype bf16 --checkpoint xlm-roberta-base --modelname XLMRobertaModel` then fails with:

```
error: "<eval_with_key>.2":23:20: unsupported by backend contract: Unimplemented operator 'aten.scalar_tensor'
note: "<eval_with_key>.2":23:20: see current operation: %246 = "torch.operator"(%0, %3, %0, %221, %4) {name = "aten.scalar_tensor"} : (!torch.int, !torch.int, !torch.int, !torch.Device, !torch.none) -> !torch.tensor
```