### PR TITLE
.github/workflows/buildRelease.yml: Also build packages for python 3.10

### DIFF
--- a/.github/workflows/buildRelease.yml
+++ b/.github/workflows/buildRelease.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         package: [ torch-mlir ]
-        py_version: [ cp38-cp38 ]
+        py_version: [ cp38-cp38, cp310-cp310 ]
         torch-version: [stable] # nightly
         exclude:
           - package: torch-mlir-core


### PR DESCRIPTION
To allow users on Ubuntu 22.04 to use the package.