### PR TITLE
lib/Dialect/Torch/IR/TorchOps.cpp: Canonicalize rank changing broadcast_to into reshape + broadcast_to

### DIFF
--- a/e2e_testing/xfail_sets.py
+++ b/e2e_testing/xfail_sets.py
@@ -326,6 +326,7 @@ STABLEHLO_PASS_SET = {
     "BmmModule_basic",
     "BroadcastToModule_basic",
     "BroadcastToSameRankStaticModule_basic",
+    "BroadcastToDifferentRankStaticModule_basic",
     "BroadcastZeroRankInputStaticModule_basic",
     "BroadcastListConstructWithMinusOneModule_basic",
     "BucketizeTensorStaticFloatModule_basic",

--- a/e2e_testing/xfail_sets.py
+++ b/e2e_testing/xfail_sets.py
@@ -968,6 +968,7 @@ TOSA_PASS_SET = {
     "ReduceSumFloatModule_basic",
     "ReduceSumSignedIntModule_basic",
     "ReduceSumUnsignedIntModule_basic",
+    "BroadcastToDifferentRankStaticModule_basic",
     "BroadcastToSameRankStaticModule_basic",
     "BroadcastZeroRankInputStaticModule_basic",
     "BroadcastListConstructWithMinusOneModule_basic",

--- a/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td
+++ b/include/torch-mlir/Dialect/Torch/IR/GeneratedTorchOps.td
@@ -7179,6 +7179,7 @@ def Torch_AtenBroadcastToOp : Torch_Op<"aten.broadcast_to", [
       printDefaultTorchOp(printer, *this, 2, 1);
     }
   }];
+  let hasCanonicalizer = 1;
 }
 
 def Torch_AtenIndexTensorOp : Torch_Op<"aten.index.Tensor", [

--- a/lib/Dialect/Torch/IR/TorchOps.cpp
+++ b/lib/Dialect/Torch/IR/TorchOps.cpp
@@ -2404,6 +2404,63 @@ void PrimDeviceOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
   });
 }
 
+void AtenBroadcastToOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
+                                               MLIRContext *context) {
+  patterns.add(+[](AtenBroadcastToOp op, PatternRewriter &rewriter) {
+    auto selfTy = dyn_cast<BaseTensorType>(op.getSelf().getType());
+
+    if (!selfTy || !selfTy.areAllSizesKnown()) {
+      return rewriter.notifyMatchFailure(op,
+                                         "only applies when selfTy is known");
+    }
+
+    SmallVector<int64_t> resultShape;
+    if (!matchPattern(op.getSize(), m_TorchListOfConstantInts(resultShape))) {
+      return rewriter.notifyMatchFailure(
+          op, "size must consist of Scalar constants");
+    }
+
+    SmallVector<int64_t> selfShape{selfTy.getSizes()};
+    if (resultShape.size() == selfShape.size()) {
+      return rewriter.notifyMatchFailure(op, "nothing to do");
+    }
+
+    size_t extraDims = resultShape.size() - selfShape.size();
+    for (unsigned i = 0; i < extraDims; i++) {
+      if (resultShape[i] != 1) {
+        return rewriter.notifyMatchFailure(
+            op, "unimplemented: broadcasts that increases rank must add "
+                "dimensions with size 1.");
+      }
+    }
+
+    // Create 1, ..., 1, inputShape[0], inputShape[1], inputShape[2]
+    SmallVector<int64_t> reshapeShape = resultShape;
+    for (unsigned i = 0; i < selfShape.size(); i++)
+      reshapeShape[extraDims + i] = selfShape[i];
+
+    SmallVector<Value> sizes;
+    for (unsigned i = 0; i < reshapeShape.size(); i++) {
+      sizes.push_back(rewriter.create<Torch::ConstantIntOp>(
+          op->getLoc(), rewriter.getI64IntegerAttr(reshapeShape[i])));
+    }
+
+    auto listType = Torch::ListType::get(Torch::IntType::get(op.getContext()));
+
+    Value dims =
+        rewriter.create<PrimListConstructOp>(op->getLoc(), listType, sizes);
+
+    auto input = rewriter.create<AtenViewOp>(
+        op->getLoc(),
+        selfTy.getWithSizesAndDtype(reshapeShape, selfTy.getDtype()),
+        op.getSelf(), dims);
+
+    rewriter.replaceOpWithNewOp<AtenBroadcastToOp>(op, op.getType(), input,
+                                                   op.getSize());
+    return success();
+  });
+}
+
 //===----------------------------------------------------------------------===//
 // AtenIntTensorOp
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/Torch/IR/TorchOps.cpp
+++ b/lib/Dialect/Torch/IR/TorchOps.cpp
@@ -2425,6 +2425,11 @@ void AtenBroadcastToOp::getCanonicalizationPatterns(RewritePatternSet &patterns,
       return rewriter.notifyMatchFailure(op, "nothing to do");
     }
 
+    if (resultShape.size() <= selfShape.size()) {
+      return rewriter.notifyMatchFailure(
+          op, "unexpected result rank smaller than self rank");
+    }
+
     size_t extraDims = resultShape.size() - selfShape.size();
     for (unsigned i = 0; i < extraDims; i++) {
       if (resultShape[i] != 1) {

--- a/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
+++ b/python/torch_mlir/dialects/torch/importer/jit_ir/build_tools/torch_ods_gen.py
@@ -493,7 +493,7 @@ def emit_ops(emitter_td: TextEmitter, registry: Registry):
     emit("aten::empty.memory_format : (int[], int?, int?, Device?, bool?, int?) -> (Tensor)")
     emit("aten::expand : (Tensor, int[], bool) -> (Tensor)")
     emit("aten::expand_as : (Tensor, Tensor) -> (Tensor)")
-    emit("aten::broadcast_to : (Tensor, int[]) -> (Tensor)")
+    emit("aten::broadcast_to : (Tensor, int[]) -> (Tensor)", has_canonicalizer=True)
     emit("aten::index.Tensor : (Tensor, Tensor?[]) -> (Tensor)")
     emit("aten::index.Tensor_hacked_twin : (Tensor, Tensor[]) -> (Tensor)")
     emit("aten::index_select : (Tensor, int, Tensor) -> (Tensor)")

--- a/python/torch_mlir_e2e_test/test_suite/basic.py
+++ b/python/torch_mlir_e2e_test/test_suite/basic.py
@@ -1286,6 +1286,28 @@ def BroadcastToModule_basic(module, tu: TestUtils):
 # ==============================================================================
 
 
+class BroadcastToDifferentRankStaticModule(torch.nn.Module):
+
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([2, 8], torch.float32, True),
+    ])
+    def forward(self, x):
+        return torch.broadcast_to(x, [1, 2, 8])
+
+
+@register_test_case(module_factory=lambda: BroadcastToDifferentRankStaticModule())
+def BroadcastToDifferentRankStaticModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(2, 8))
+
+
+# ==============================================================================
+
+
 class BroadcastToSameRankStaticModule(torch.nn.Module):
 
     def __init__(self):


### PR DESCRIPTION
The aten.broadcast_to op both does broadcasting but can also increase the rank by adding dimensions with size 1.
The torch->tosa lowering only handles broadcast_to that are not increasing the rank. To also help other backends, I added a canonicalizer for broadcast_to that splits into into a reshape and a non-rank changing broadcast_to.