### PR TITLE
repro: Consider %arg0 to be an SSA for matching the error message

### DIFF
--- a/python/torch_mlir/repro.py
+++ b/python/torch_mlir/repro.py
@@ -63,7 +63,7 @@ _REs = {
     r'note: ["<>a-zA-Z0-9._/-]+:[0-9]+:[0-9]+: (.*)': r"note: \1",
     r"note: unknown:": r"note:",
     r"note: this is likely due to a missing transfer function in abstract_interp_lib_gen.py": "",
-    r"%[0-9]+": "%SSA",
+    r"%(arg)?[0-9]+": "%SSA",
     r"\[[0-9]+(,[0-9]+)*\]": r"[dims]",
 }
 


### PR DESCRIPTION
When creating a reproducer, consider the error messages
`error: failed to legalize operation 'torch.aten.slice.Tensor' that was explicitly marked illegal, note: see current operation: %SSA = "torch.aten.slice.Tensor"(%13`
and
`error: failed to legalize operation 'torch.aten.slice.Tensor' that was explicitly marked illegal, note: see current operation: %SSA = "torch.aten.slice.Tensor"(%arg0`
the same error to allow to create smaller reproducers.