### PR TITLE
do: Use use_make_fx flag on compile()

### DIFF
--- a/python/torch_mlir/__init__.py
+++ b/python/torch_mlir/__init__.py
@@ -27,7 +27,7 @@ from torch_mlir_e2e_test.tosa_backends.linalg_on_tensors import (
 from ._mlir_libs._mlir.ir import Module
 
 from .repro import reproduce
-from .compiler_utils import model_to_fxgraph
+from .compiler_utils import prepare_model
 
 class OutputType(Enum):
     """The kind of output that `torch_mlir.compile` can produce.
@@ -489,9 +489,9 @@ def do(model: torch.nn.Module,
             version = "dev"
         print(f"Using torch-mlir {version}")
 
-    fx_g = model_to_fxgraph(model, *model_args, dtype=dtype, **model_kwargs)
+    fx_g = prepare_model(model, *model_args, dtype=dtype, **model_kwargs)
 
-    module = compile(fx_g,model_args,output_type=output_type)
+    module = compile(fx_g,model_args,output_type=output_type, use_make_fx=True)
     # TOSA lacks a bunch of verifiers.
     # Our best way to find issues in the TOSA IR is to try to lower to Linalg
     if output_type == "tosa":

--- a/python/torch_mlir/compiler_utils.py
+++ b/python/torch_mlir/compiler_utils.py
@@ -79,7 +79,7 @@ def run_pipeline_with_repro_report(module,
     finally:
         sys.stderr = original_stderr
 
-def model_to_fxgraph(model, *model_args, dtype = None, **model_kwargs):
+def prepare_model(model, *model_args, dtype = None, **model_kwargs):
     """
     Converts the given model to an FX graph.
     WARNING: This modifies the model in-place!
@@ -147,16 +147,4 @@ def model_to_fxgraph(model, *model_args, dtype = None, **model_kwargs):
                     return tuple(ret)
             return ret
 
-    model = Wrapper(model)
-
-    fx_g = make_fx(
-           model,
-           # sometimes there are decompositions for unsupported ops available.
-           # we don't currently know where these are listed, but just try adding
-           # the op here and see if the previously unsupported op is no longer
-           # produced (you should then see the decomposition in the IR)
-           decomposition_table=_get_decomposition_table())(*model_args)
-
-    fx_g.graph.set_codegen(torch.fx.graph.CodeGen())
-    fx_g.recompile()
-    return fx_g
+    return Wrapper(model)


### PR DESCRIPTION
Since we added that flag to torch_mlir.compile(), we can remove some duplicate code.