### PR TITLE
Backport use_make_fx from https://github.com/Xilinx/torch-mlir/pull/66

### DIFF
--- a/python/torch_mlir_e2e_test/configs/tosa_backend.py
+++ b/python/torch_mlir_e2e_test/configs/tosa_backend.py
@@ -23,14 +23,15 @@ class TosaBackendTestConfig(TestConfig):
     This class handles all the common lowering that torch-mlir does before
     reaching the linalg-on-tensors abstraction level.
     """
-    def __init__(self, backend: TosaBackend):
+    def __init__(self, backend: TosaBackend, use_make_fx: bool = False):
         super().__init__()
         self.backend = backend
+        self.use_make_fx = use_make_fx
 
     def compile(self, program: torch.nn.Module) -> Any:
         example_args = convert_annotations_to_placeholders(program.forward)
         module = torch_mlir.compile(
-            program, example_args, output_type="tosa")
+            program, example_args, output_type="tosa", use_make_fx=self.use_make_fx)
 
         return self.backend.compile(module)
 


### PR DESCRIPTION
This backports #66 but without adding the end2end test flow (which needs an LLVM bump to not crash one specific test case in the tosa fold),
and without a decomposition table in make_fx (this requires a newer torch_mlir version, which has the decomposition table in dynamo.py).

This allows us to internally already use the use_make_fx flag in our testing in a forward compatible way.

In parallel, we are upstreaming this new flag into torch-mlir.