### PR TITLE
python/torch_mlir/dynamo.py: Decompose index_select

### DIFF
--- a/e2e_testing/xfail_sets.py
+++ b/e2e_testing/xfail_sets.py
@@ -1195,6 +1195,8 @@ MAKE_FX_TOSA_PASS_SET = (TOSA_PASS_SET | {
     "SliceWholeTensorModule_basic",
     "TensorFloatModule_basic",
     "TensorIntModule_basic",
+    "IndexSelectWholeDimensionModule_basic",
+    "IndexSelectWholeTensorModule_basic",
 }) - {
 ### Test failing in make_fx_tosa but not in tosa
 

--- a/python/torch_mlir/dynamo.py
+++ b/python/torch_mlir/dynamo.py
@@ -66,6 +66,7 @@ def _get_decomposition_table():
         aten.squeeze,
         aten.cumsum,
         aten.im2col,
+        aten.index_select,
     ]
     # TODO: enable test once 2.1.0 is stable
     if torch_baseversion() >= (2, 1):


### PR DESCRIPTION
There are existing test cases in python/torch_mlir_e2e_test/test_suite/index_select.py, but they require #67 to pass.