### PR TITLE
TorchToTosa: optimize aten.fill.Scalar legalization.

### DIFF
--- a/lib/Conversion/TorchToTosa/TorchToTosa.cpp
+++ b/lib/Conversion/TorchToTosa/TorchToTosa.cpp
@@ -5071,7 +5071,10 @@ public:
       return rewriter.notifyMatchFailure(
           op, "Supplied value must be a Scalar constant");
 
-    rewriter.replaceOpWithNewOp<tosa::CastOp>(op, outType, constOp);
+    if (outType != constOp.getType())
+      rewriter.replaceOpWithNewOp<tosa::CastOp>(op, outType, constOp);
+    else
+      rewriter.replaceOp(op, constOp);
 
     return success();
   }


### PR DESCRIPTION
There is no need to create a `tosa.cast` operation if types are the same.