### PR TITLE
TorchToTosa: Legalize aten.repeat_interleave operation.

### DIFF
--- a/e2e_testing/xfail_sets.py
+++ b/e2e_testing/xfail_sets.py
@@ -17,6 +17,7 @@ LINALG_XFAIL_SET = COMMON_TORCH_MLIR_LOWERING_XFAILS | {
     "Conv1dNoPaddingModule_basic",
     "Conv1dNoPaddingTransposeModule_basic",
     "Conv1dNoPaddingGroupModule_basic",
+    "RepeatInterleaveStaticModule_basic",
     # tm_tensor.scatter' op mismatch in shape of indices and update value at dim#0
     "IndexPutImpl2DNoneIndexBroadcastStaticModule_basic"
 }
@@ -287,6 +288,9 @@ TORCHDYNAMO_XFAIL_SET = {
 
     # failed to legalize operation 'torch.aten.clamp' that was explicitly marked illegal
     "ElementwiseClampIntModule_basic",
+
+    # failed to legalize operation 'torch.constant.int'
+    "RepeatInterleaveStaticModule_basic",
 }
 
 TORCHDYNAMO_CRASHING_SET = {
@@ -1216,6 +1220,7 @@ TOSA_PASS_SET = {
     "SplitTensorListUnpackModule_basic",
     "ChunkListUnpack_Module_basic",
     "ChunkListUnpackUneven_Module_basic",
+    "RepeatInterleaveStaticModule_basic",
 }
 
 MAKE_FX_TOSA_PASS_SET = (TOSA_PASS_SET | {

--- a/python/torch_mlir_e2e_test/test_suite/basic.py
+++ b/python/torch_mlir_e2e_test/test_suite/basic.py
@@ -1482,6 +1482,27 @@ def RepeatInterleaveModule_basic(module, tu: TestUtils):
 
 # ==============================================================================
 
+class RepeatInterleaveStaticModule(torch.nn.Module):
+
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+    ])
+    def forward(self):
+        x = torch.ones((10), dtype=torch.int).fill_(3)
+        z = torch.ops.aten.repeat_interleave(x, output_size=30)
+        return z
+
+
+@register_test_case(module_factory=lambda: RepeatInterleaveStaticModule())
+def RepeatInterleaveStaticModule_basic(module, tu: TestUtils):
+    module.forward()
+
+# ==============================================================================
+
 
 class ExpandModule(torch.nn.Module):
 


### PR DESCRIPTION
Unfortunately, the legalization works only for static `repeats` and known `output_size`.