### PR TITLE
Derive output_size of repeat_interleave when inputs are broadcast(fill(x))

### DIFF
--- a/e2e_testing/xfail_sets.py
+++ b/e2e_testing/xfail_sets.py
@@ -18,6 +18,7 @@ LINALG_XFAIL_SET = COMMON_TORCH_MLIR_LOWERING_XFAILS | {
     "Conv1dNoPaddingTransposeModule_basic",
     "Conv1dNoPaddingGroupModule_basic",
     "RepeatInterleaveStaticModule_basic",
+    "RepeatInterleaveFillModule_basic",
     # tm_tensor.scatter' op mismatch in shape of indices and update value at dim#0
     "IndexPutImpl2DNoneIndexBroadcastStaticModule_basic"
 }
@@ -277,6 +278,7 @@ TORCHDYNAMO_XFAIL_SET = {
     "ScatterValueIntModule_basic",
     # ERROR: Unsupported: dynamic shape operator: aten.repeat_interleave.Tensor
     "RepeatInterleaveModule_basic",
+    "RepeatInterleaveFillModule_basic",
 
     # failed to legalize operation 'torch.aten.convolution' that was explicitly marked illegal
     "Conv1dNoPaddingModule_basic",
@@ -1226,6 +1228,7 @@ TOSA_PASS_SET = {
     "ChunkListUnpack_Module_basic",
     "ChunkListUnpackUneven_Module_basic",
     "RepeatInterleaveStaticModule_basic",
+    "RepeatInterleaveFillModule_basic",
 }
 
 MAKE_FX_TOSA_PASS_SET = (TOSA_PASS_SET | {
@@ -1490,5 +1493,6 @@ LTC_XFAIL_SET = {
     "ScatterValueFloatModule_basic",
     "ScatterValueIntModule_basic",
     "RepeatInterleaveModule_basic",
+    "RepeatInterleaveFillModule_basic",
     "Im2ColModule_basic",
 }

--- a/lib/Dialect/Torch/Transforms/LowerToBackendContract.cpp
+++ b/lib/Dialect/Torch/Transforms/LowerToBackendContract.cpp
@@ -491,4 +491,11 @@ static void markDecomposedOpsAsIllegal(MLIRContext *context,
         auto opName = opOp->getAttr("name").cast<StringAttr>().getValue();
         return backendLegalOpsSet.contains(opName);
       });
+
+  // TODO: We need this for TOSA; other backends might be fine with this op
+  // having a dynamic sized output tensor.
+  target.addDynamicallyLegalOp<AtenRepeatInterleaveTensorOp>(
+    [](AtenRepeatInterleaveTensorOp op) {
+      return op.getOutputSize().getDefiningOp<ConstantIntOp>();
+  });
 }

--- a/python/torch_mlir_e2e_test/test_suite/basic.py
+++ b/python/torch_mlir_e2e_test/test_suite/basic.py
@@ -1481,6 +1481,28 @@ def RepeatInterleaveModule_basic(module, tu: TestUtils):
     module.forward(torch.tensor([3, 1, 2, 4], dtype=torch.int))
 
 # ==============================================================================
+class RepeatInterleaveFillModule(torch.nn.Module):
+
+    def __init__(self):
+        super().__init__()
+
+    @export
+    @annotate_args([
+        None,
+        ([1], torch.int, True),
+    ])
+    def forward(self, x):
+        x = torch.ops.aten.fill_(x, 2)
+        x = torch.ops.aten.expand(x, [16])
+        return torch.ops.aten.repeat_interleave(x)
+
+
+@register_test_case(module_factory=lambda: RepeatInterleaveFillModule())
+def RepeatInterleaveFillModule_basic(module, tu: TestUtils):
+    module.forward(torch.tensor([1], dtype=torch.int))
+
+
+# ==============================================================================
 
 class RepeatInterleaveStaticModule(torch.nn.Module):
 


### PR DESCRIPTION
This is a different approach where I will add the output_size to repeat_interleave if the repeats argument is produced by broadcast(fill.Scalar(...)).
Then the existing TOSA lowering works.