### PR TITLE
Allow to pass None as arguments to the model

### DIFF
--- a/e2e_testing/xfail_sets.py
+++ b/e2e_testing/xfail_sets.py
@@ -295,6 +295,10 @@ TORCHDYNAMO_XFAIL_SET = {
 
     # failed to legalize operation 'torch.constant.int'
     "RepeatInterleaveStaticModule_basic",
+
+    # torch._dynamo.exc.InternalTorchDynamoError: 'NoneType' object has no attribute 'clone'
+    "NoneArgumentModule_basic",
+    "NoneArgumentNoneAnnotationModule_basic",
 }
 
 TORCHDYNAMO_CRASHING_SET = {
@@ -842,6 +846,9 @@ STABLEHLO_PASS_SET = {
     "RandIntModule_basic",
     "RandIntPinMemoryModule_basic",
     "UniformNoCorrelationModule_basic",
+    "OptionalArgumentModule_basic",
+    "NoneArgumentModule_basic",
+    "NoneArgumentNoneAnnotationModule_basic",
 }
 
 # Write the TOSA set as a "passing" set as it is very early in development
@@ -1235,6 +1242,9 @@ TOSA_PASS_SET = {
     "ChunkListUnpackUneven_Module_basic",
     "RepeatInterleaveStaticModule_basic",
     "RepeatInterleaveFillModule_basic",
+    "OptionalArgumentModule_basic",
+    "NoneArgumentModule_basic",
+    "NoneArgumentNoneAnnotationModule_basic",
 }
 
 MAKE_FX_TOSA_PASS_SET = (TOSA_PASS_SET | {

--- a/python/torch_mlir/__init__.py
+++ b/python/torch_mlir/__init__.py
@@ -28,7 +28,7 @@ from torch_mlir_e2e_test.tosa_backends.linalg_on_tensors import (
 from ._mlir_libs._mlir.ir import Module
 
 from .repro import reproduce
-from .compiler_utils import prepare_model
+from .compiler_utils import prepare_model, map_kwargs_into_args
 
 class OutputType(Enum):
     """The kind of output that `torch_mlir.compile` can produce.
@@ -589,6 +589,8 @@ def do(model: torch.nn.Module,
     WARNING: This modifies the model in-place!
     """
 
+    model_args = map_kwargs_into_args(model, model_args, model_kwargs)
+
     if verbose:
         try:
             version = importlib.metadata.version('torch-mlir')
@@ -596,7 +598,7 @@ def do(model: torch.nn.Module,
             version = "dev"
         print(f"Using torch-mlir {version}")
 
-    model, golden = prepare_model(model, *model_args, dtype=dtype, **model_kwargs)
+    model, golden = prepare_model(model, *model_args, dtype=dtype)
 
     compile_output_type = output_type
     if compile_output_type in ("check-tosa", "run-tosa"):

--- a/python/torch_mlir/repro.py
+++ b/python/torch_mlir/repro.py
@@ -27,7 +27,7 @@ from torch_mlir.dynamo import _get_decomposition_table
 from torch.fx.experimental.proxy_tensor import make_fx
 import torch.fx as fx
 
-from .compiler_utils import prepare_model
+from .compiler_utils import prepare_model, map_kwargs_into_args
 from torch_mlir_e2e_test.tosa_backends.linalg_on_tensors import (
             LinalgOnTensorsTosaBackend,
     )
@@ -170,6 +170,7 @@ def reproduce(
     dtype=None,
     expected_error: Optional[str] = None,
     verbose=False,
+    **model_kwargs,
 ):
     """
     Reduces the given model while ensuring that the error message seen by passing
@@ -181,6 +182,8 @@ def reproduce(
     error message. You can also pass it explicitly via the expected_error
     parameter.
     """
+
+    inputs = map_kwargs_into_args(model, inputs, model_kwargs)
 
     model, _ = prepare_model(model, *inputs, dtype=dtype)
     fx_g = make_fx(

--- a/python/torch_mlir_e2e_test/configs/utils.py
+++ b/python/torch_mlir_e2e_test/configs/utils.py
@@ -25,6 +25,8 @@ def recursively_convert_to_numpy(o: Any):
         return o
     if isinstance(o, int):
         return o
+    if o is None:
+        return o
     raise Exception(f"Unexpected Python function input: {o}")
 
 def recursively_convert_from_numpy(o: Any):

--- a/python/torch_mlir_e2e_test/framework.py
+++ b/python/torch_mlir_e2e_test/framework.py
@@ -71,6 +71,8 @@ def clone_torch_script_value(v: TorchScriptValue):
         }
     if isinstance(v, float) or isinstance(v, int) or isinstance(v, str):
         return v
+    if v is None:
+        return v
     assert False, "unhandled cloning of TorchScriptValue value type"
 
 

--- a/python/torch_mlir_e2e_test/linalg_on_tensors_backends/refbackend.py
+++ b/python/torch_mlir_e2e_test/linalg_on_tensors_backends/refbackend.py
@@ -107,10 +107,13 @@ class RefBackendInvoker:
         def invoke(*args):
             ffi_args = []
             for arg in args:
-                assert_arg_type_is_supported(arg.dtype)
-                ffi_args.append(
-                    ctypes.pointer(
-                        ctypes.pointer(get_unranked_memref_descriptor(arg))))
+                if arg is None:
+                    ffi_args.append(None)
+                else:
+                    assert_arg_type_is_supported(arg.dtype)
+                    ffi_args.append(
+                        ctypes.pointer(
+                            ctypes.pointer(get_unranked_memref_descriptor(arg))))
 
             self.ee.invoke(function_name, *ffi_args)
             result = self.result

--- a/python/torch_mlir_e2e_test/reporting.py
+++ b/python/torch_mlir_e2e_test/reporting.py
@@ -163,6 +163,10 @@ class ValueReport:
                     f'value ({TensorSummary(value)}) is not close to golden value ({TensorSummary(golden)})'
                 )
             return
+        if golden is None:
+            if value is not None:
+                return self._record_mismatch_type_failure('None', value)
+            return
         return self._record_failure(
             f'unexpected golden value of type `{golden.__class__.__name__}`')
 

--- a/python/torch_mlir_e2e_test/test_suite/basic.py
+++ b/python/torch_mlir_e2e_test/test_suite/basic.py
@@ -4272,3 +4272,53 @@ class Im2Col_Module(torch.nn.Module):
 @register_test_case(module_factory=lambda: Im2Col_Module())
 def Im2ColModule_basic(module, tu: TestUtils):
     module.forward(tu.rand(3,4,5,2))
+# ==============================================================================
+
+class OptionalArgumentModule(torch.nn.Module):
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1, -1], torch.float32, True),
+        ([-1, -1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, x, y = None):
+        return x
+
+@register_test_case(module_factory=lambda: OptionalArgumentModule())
+def OptionalArgumentModule_basic(module, tu: TestUtils):
+    module.forward(tu.rand(3,4,5,2))
+
+# ==============================================================================
+
+class NoneArgumentModule(torch.nn.Module):
+
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1, -1, -1], torch.float32, True),
+        ([-1, -1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, x, y):
+        return y
+
+@register_test_case(module_factory=lambda: NoneArgumentModule())
+def NoneArgumentModule_basic(module, tu: TestUtils):
+    module.forward(None, tu.rand(3,4,5,2))
+
+# ==============================================================================
+
+class NoneArgumentNoneAnnotationModule(torch.nn.Module):
+
+    @export
+    @annotate_args([
+        None,
+        None,
+        ([-1, -1, -1, -1], torch.float32, True),
+    ])
+    def forward(self, x, y):
+        return y
+
+@register_test_case(module_factory=lambda: NoneArgumentNoneAnnotationModule())
+def NoneArgumentNoneAnnotationModule_basic(module, tu: TestUtils):
+    module.forward(None, tu.rand(3,4,5,2))

--- a/python/torch_mlir_e2e_test/utils.py
+++ b/python/torch_mlir_e2e_test/utils.py
@@ -15,8 +15,11 @@ def convert_annotations_to_placeholders(forward_method):
     placeholders = []
     # Skip the "self" annotation.
     for annotation in annotations[1:]:
-        if not annotation[2]:
-            raise ValueError(
-                "Can only compile inputs annotated as having value semantics.")
-        placeholders.append(TensorPlaceholder(annotation[0], annotation[1]))
+        if annotation is None:
+            placeholders.append(None)
+        else:
+            if not annotation[2]:
+                raise ValueError(
+                    "Can only compile inputs annotated as having value semantics.")
+            placeholders.append(TensorPlaceholder(annotation[0], annotation[1]))
     return placeholders


### PR DESCRIPTION
See new test cases. Essentially, we sometimes need to call a model with optional arguments in the middle of the argument list,
like
`transformer.forward(input_ids, None, attention_mask)`.
The main difficulty is that torch_mlir doesn't have shape and dtype information for the None argument.
But on the other hand, that argument is also not used, because typically we see
```
if arg2 is None:
  arg2 = torch.ones(...)
```
which after make_fx tracing gets flattened into
```
arg2 = torch.ones(...)
```
which makes the argument itself unused in SSA form (and instead, there are only uses of the torch.ones return value).

Thus we can just invent shape and dtype, like `tensor<0xf32>`.