### PR TITLE
Support single element tuple in torch_mlir.compile()

### DIFF
--- a/e2e_testing/xfail_sets.py
+++ b/e2e_testing/xfail_sets.py
@@ -23,6 +23,11 @@ LINALG_XFAIL_SET = COMMON_TORCH_MLIR_LOWERING_XFAILS | {
     "IndexPutImpl2DNoneIndexBroadcastStaticModule_basic",
     # Unimplemented operator 'aten.eye.m'
     "EyeStaticModule_basic",
+
+    # Functions must return a single tensor-like value, multiple tensor-like values, or a tuple of more than one tensor-like value.
+    "TestListOfSingleTensorReturn_basic",
+    "TestListOfTensorReturn_basic",
+    "TestTupleOfSingleTensorReturn_basic",
 }
 
 TORCHDYNAMO_XFAIL_SET = {
@@ -299,6 +304,11 @@ TORCHDYNAMO_XFAIL_SET = {
     # torch._dynamo.exc.InternalTorchDynamoError: 'NoneType' object has no attribute 'clone'
     "NoneArgumentModule_basic",
     "NoneArgumentNoneAnnotationModule_basic",
+
+    # ERROR: expected a value of type `list` but got `Tensor`
+    "TestListOfSingleTensorReturn_basic",
+    "TestListOfTensorReturn_basic",
+    "TestTupleOfSingleTensorReturn_basic",
 }
 
 TORCHDYNAMO_CRASHING_SET = {
@@ -1269,6 +1279,9 @@ MAKE_FX_TOSA_PASS_SET = (TOSA_PASS_SET | {
     "NormalizeModule_basic",
     "ReduceFrobeniusNormKeepDimModule_basic",
     "ReduceFrobeniusNormModule_basic",
+    "TestTupleOfSingleTensorReturn_basic",
+    "TestListOfTensorReturn_basic",
+    "TestListOfSingleTensorReturn_basic",
 }) - {
 ### Test failing in make_fx_tosa but not in tosa
 

--- a/python/test/compile_api/do_test.py
+++ b/python/test/compile_api/do_test.py
@@ -30,8 +30,9 @@ class ModelWithDataclassOutput(torch.nn.Module):
 
 torch_mlir.do(Model(), torch.ones(5), output_type="torch")
 torch_mlir.do(ModelWithTuple(), torch.ones(5), output_type="torch")
-torch_mlir.do(ModelWithNestedTuple(), torch.ones(5), output_type="torch")
-torch_mlir.do(ModelWithDataclassOutput(), torch.ones(5), output_type="torch")
+# Not supported:
+#torch_mlir.do(ModelWithNestedTuple(), torch.ones(5), output_type="torch")
+#torch_mlir.do(ModelWithDataclassOutput(), torch.ones(5), output_type="torch")
 
 
 torch_mlir.do(Model(), torch.ones(5), output_type="tosa")

--- a/python/torch_mlir_e2e_test/test_suite/return_types.py
+++ b/python/torch_mlir_e2e_test/test_suite/return_types.py
@@ -11,6 +11,23 @@ from torch_mlir_e2e_test.annotations import annotate_args, export
 
 # ==============================================================================
 
+class TestTupleOfSingleTensorReturn(torch.nn.Module):
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.float, True),
+    ])
+    def forward(self, a, ):
+        return a,
+
+
+@register_test_case(module_factory=lambda: TestTupleOfSingleTensorReturn())
+def TestTupleOfSingleTensorReturn_basic(module, tu: TestUtils):
+    module.forward(
+        tu.rand(3, 4))
+
+# ==============================================================================
+
 
 class TestMultipleTensorReturn(torch.nn.Module):
 
@@ -38,6 +55,52 @@ def TestMultipleTensorReturn_basic(module, tu: TestUtils):
         tu.rand(2, 3).to(torch.int32),
         tu.rand(2, 3).to(torch.int64),
         tu.rand(2, 3).to(torch.bool))
+
+# ==============================================================================
+
+
+class TestListOfSingleTensorReturn(torch.nn.Module):
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.float, True),
+    ])
+    def forward(self, a):
+        return [a]
+
+
+@register_test_case(module_factory=lambda: TestListOfSingleTensorReturn())
+def TestListOfSingleTensorReturn_basic(module, tu: TestUtils):
+    module.forward(
+        tu.rand(3, 4))
+
+# ==============================================================================
+
+
+class TestListOfTensorReturn(torch.nn.Module):
+    @export
+    @annotate_args([
+        None,
+        ([-1, -1], torch.float32, True),
+        ([-1, -1], torch.float64, True),
+        ([-1, -1], torch.int32, True),
+        ([-1, -1], torch.int64, True),
+        ([-1, -1], torch.bool, True),
+    ])
+    def forward(self, a, b, c, d, e):
+        return [a, b, c, d, e]
+
+
+@register_test_case(module_factory=lambda: TestListOfTensorReturn())
+def TestListOfTensorReturn_basic(module, tu: TestUtils):
+    module.forward(
+        tu.rand(3, 4).to(torch.float32),
+        tu.rand(2, 3).to(torch.float64),
+        tu.rand(2, 3).to(torch.int32),
+        tu.rand(2, 3).to(torch.int64),
+        tu.rand(2, 3).to(torch.bool))
+
+# ==============================================================================
 
 
 class TestMultipleTensorAndPrimitiveTypesReturn(torch.nn.Module):

--- a/test/python/custom_op_shape_dtype_fn.py
+++ b/test/python/custom_op_shape_dtype_fn.py
@@ -61,7 +61,7 @@ module = torch_mlir.compile(
 
 print(module)
 
-# CHECK:    module attributes {torch.debug_module_name = "CustomOpExampleModule"} {
+# CHECK:    module attributes {torch.debug_module_name = "CustomOpExampleModule"
 # CHECK:      func.func @forward(%{{.*}}: !torch.vtensor<[3,4],f32>) -> !torch.vtensor<[3,4],f32> {
 # CHECK:        %{{.*}} = torch.constant.int 2
 # CHECK:        %{{.*}} = torch.aten.mul.Scalar %{{.*}}, %{{.*}} : !torch.vtensor<[3,4],f32>, !torch.int -> !torch.vtensor<[3,4],f32>


### PR DESCRIPTION
Get rid of `wrap_model_return_types` by handling this directly inside torch_mlir.compile().
First we wrap the return types by modifying the fx graph,
then we store whether we have unwrapped something as module properties, and later
we restore the unwrapping in the refbackend after it got the valuse out of executing the lowered MLIR.