### PR TITLE
torch.aten.max pool2d with indices

### DIFF
--- a/e2e_testing/xfail_sets.py
+++ b/e2e_testing/xfail_sets.py
@@ -1275,15 +1275,10 @@ MAKE_FX_TOSA_PASS_SET = (TOSA_PASS_SET | {
 
     # 'tensor.empty' op incorrect number of dynamic sizes, has 1, expected 0
     "BatchNorm1DStaticShapeModule_basic",
+    "ResNet18StaticModule_basic",
 
     # Dynamic shape, has extra unsupported broadcast ops
     "Matmul_3d",
-
-    # failed to legalize operation 'torch.aten.max_pool2d_with_indices
-    "MaxPool2dEmptyStrideStaticModule_basic",
-    "MaxPool2dStaticCeilModeTrueModule_basic",
-    "MaxPool2dStaticModule_basic",
-    "ResNet18StaticModule_basic",
 
     # Unimplemented operator 'aten._index_put_impl_.hacked_twin'
     "IndexPutImpl1DFloatNonAccumulateModule_basic",


### PR DESCRIPTION
I also needed to update the LLVM branch to be in sync with [xilinx/llvm-project feature/backport_ea1_ops](https://github.com/Xilinx/torch-mlir/commit/f496fd488f50c1c056e583c7bb5c10ef2de0c9fb)
because they contain fix for a crash in TOSA folds.