### PR TITLE
test/CAPI/CMakeLists.txt: Depend on FileCheck

### DIFF
--- a/test/CAPI/CMakeLists.txt
+++ b/test/CAPI/CMakeLists.txt
@@ -10,6 +10,6 @@ target_link_libraries(
 
 add_lit_testsuite(check-torch-mlir-capi "Running the torch-mlir CAPI tests"
         ${CMAKE_CURRENT_BINARY_DIR}
-        DEPENDS torch-mlir-capi-torch-test
+        DEPENDS torch-mlir-capi-torch-test FileCheck
         )
 set_target_properties(check-torch-mlir-capi PROPERTIES FOLDER "Tests")


### PR DESCRIPTION
I saw test failing when FileCheck wasn't already build