### PR TITLE
Add additional source for pytorch+torchvision whls

### DIFF
--- a/pytorch-requirements.txt
+++ b/pytorch-requirements.txt
@@ -1,3 +1,4 @@
 -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+-f https://xilinx.github.io/torch-mlir/package-index/
 --pre
 torch==2.1.0.dev20230710

--- a/pytorch-requirements.txt
+++ b/pytorch-requirements.txt
@@ -1,4 +1,7 @@
 -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+# The nightly wheels for pytorch are regularly deleted and we don't bump the
+# versions at the same pace. The wheels will therefore be cached on the xilinx
+# release page, and we use this page as an additional source for the wheels.
 -f https://xilinx.github.io/torch-mlir/package-index/
 --pre
 torch==2.1.0.dev20230710

--- a/torchvision-requirements.txt
+++ b/torchvision-requirements.txt
@@ -1,3 +1,4 @@
 -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+-f https://xilinx.github.io/torch-mlir/package-index/
 --pre
 torchvision==0.16.0.dev20230710

--- a/torchvision-requirements.txt
+++ b/torchvision-requirements.txt
@@ -1,4 +1,7 @@
 -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+# The nightly wheels for torchvision are regularly deleted and we don't bump the
+# versions at the same pace. The wheels will therefore be cached on the xilinx
+# release page, and we use this page as an additional source for the wheels.
 -f https://xilinx.github.io/torch-mlir/package-index/
 --pre
 torchvision==0.16.0.dev20230710


### PR DESCRIPTION
In case the version of pytorch and torchvision we refer to is deleted on pytorch.org, we should derive it from our release page.