### PR TITLE
[FXML-4647] Allow TOSA dialect ops in Torch-to-Linalg pipeline

### DIFF
--- a/include/torch-mlir/Dialect/TorchConversion/Transforms/Passes.h
+++ b/include/torch-mlir/Dialect/TorchConversion/Transforms/Passes.h
@@ -22,16 +22,24 @@ class ModuleOp;
 namespace torch {
 namespace TorchConversion {
 
+#define GEN_PASS_DECL_VERIFYLINALGONTENSORSBACKENDCONTRACT
+#include "torch-mlir/Dialect/TorchConversion/Transforms/Passes.h.inc"
+
 struct TorchBackendToLinalgOnTensorsBackendPipelineOptions
-    : public PassPipelineOptions<TorchBackendToLinalgOnTensorsBackendPipelineOptions> {
+    : public PassPipelineOptions<
+          TorchBackendToLinalgOnTensorsBackendPipelineOptions> {
   PassOptions::Option<bool> verify{
       *this, "verify",
       llvm::cl::desc("verify the backend contract after lowering"),
       llvm::cl::init(true)};
-PassOptions::Option<bool> useMlprogram{
+  PassOptions::Option<bool> useMlprogram{
       *this, "use-mlprogram",
       llvm::cl::desc("run convert-torch-conversion-to-mlprogram"),
       llvm::cl::init(true)};
+  PassOptions::Option<bool> allowTosaDialect{
+      *this, "allow-tosa-dialect",
+      llvm::cl::desc("allow TOSA dialect ops to remain after conversion"),
+      llvm::cl::init(false)};
 };
 
 /// Creates a pipeline that lowers from the torch backend contract to the
@@ -82,7 +90,8 @@ std::unique_ptr<InterfacePass<FunctionOpInterface>>
 createConvertCustomQuantOpPass();
 
 std::unique_ptr<OperationPass<ModuleOp>>
-createVerifyLinalgOnTensorsBackendContractPass();
+createVerifyLinalgOnTensorsBackendContractPass(
+    VerifyLinalgOnTensorsBackendContractOptions options = {});
 
 std::unique_ptr<OperationPass<ModuleOp>> createVerifyTosaBackendContractPass();
 

--- a/include/torch-mlir/Dialect/TorchConversion/Transforms/Passes.td
+++ b/include/torch-mlir/Dialect/TorchConversion/Transforms/Passes.td
@@ -35,6 +35,9 @@ def FinalizingBackendTypeConversion
 def VerifyLinalgOnTensorsBackendContract : Pass<"torch-verify-linalg-on-tensors-backend-contract", "ModuleOp"> {
   let summary = "Verifies conformity to the linalg-on-tensors backend contract";
   let constructor = "mlir::torch::TorchConversion::createVerifyLinalgOnTensorsBackendContractPass()";
+  let options = [
+    Option<"allowTosaDialect", "allow-tosa-dialect", "bool",/*default=*/"false", "Allow TOSA dialect ops through">
+  ];
 }
 
 def VerifyTosaBackendContract : Pass<"torch-verify-tosa-backend-contract", "ModuleOp"> {

--- a/lib/Dialect/TorchConversion/Transforms/Passes.cpp
+++ b/lib/Dialect/TorchConversion/Transforms/Passes.cpp
@@ -44,7 +44,8 @@ namespace reg {
 
 void mlir::torch::registerTorchConversionPasses() {
   reg::registerPasses();
-  mlir::PassPipelineRegistration<TorchConversion::TorchBackendToLinalgOnTensorsBackendPipelineOptions>(
+  mlir::PassPipelineRegistration<
+      TorchConversion::TorchBackendToLinalgOnTensorsBackendPipelineOptions>(
       "torch-backend-to-linalg-on-tensors-backend-pipeline",
       "Pipeline lowering torch backend contract to linalg-on-tensors backend "
       "contract.",
@@ -66,7 +67,8 @@ void mlir::torch::registerTorchConversionPasses() {
 }
 
 void TorchConversion::createTorchBackendToLinalgOnTensorsBackendPipeline(
-    OpPassManager &pm, const TorchBackendToLinalgOnTensorsBackendPipelineOptions& options) {
+    OpPassManager &pm,
+    const TorchBackendToLinalgOnTensorsBackendPipelineOptions &options) {
   // We want to fuse quantized operations together before lowering to linalg.
   pm.addNestedPass<func::FuncOp>(Torch::createFuseQuantizedOpsPass());
 
@@ -104,8 +106,10 @@ void TorchConversion::createTorchBackendToLinalgOnTensorsBackendPipeline(
   // Verify that we have lowered to the form that linalg on tensors backends
   // expect. This fails compilation (signalPassFailure) if the IR is not in the
   // correct form.
-  if (options.verify)
-    pm.addPass(TorchConversion::createVerifyLinalgOnTensorsBackendContractPass());
+  if (options.verify) {
+    pm.addPass(TorchConversion::createVerifyLinalgOnTensorsBackendContractPass(
+        {.allowTosaDialect = options.allowTosaDialect}));
+  }
 }
 
 void TorchConversion::createTorchBackendToTosaBackendPipeline(

--- a/test/Dialect/TorchConversion/verify-linalg-on-tensors-backend-contract-with-tosa.mlir
+++ b/test/Dialect/TorchConversion/verify-linalg-on-tensors-backend-contract-with-tosa.mlir
@@ -1,0 +1,7 @@
+// RUN: torch-mlir-opt -p 'builtin.module(torch-verify-linalg-on-tensors-backend-contract{allow-tosa-dialect=1})' -split-input-file -verify-diagnostics -allow-unregistered-dialect %s | FileCheck %s
+
+// CHECK: func.func @tosa
+func.func @tosa(%arg0: tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %1 = tosa.abs %arg0 : (tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %1 : tensor<?x?xf32>
+}


### PR DESCRIPTION
TOSA ops can be lowered by the TosaXtenToLinalg pipeline. If this is done, then a flag can allow these TOSA ops through the Torch->Linalg pipeline instead of having them illegal.

Breaking [the contract](https://github.com/llvm/torch-mlir/blob/main/docs/architecture.md) looks like a very bad idea. I wouldn't see this making it upstream.