### PR TITLE
Fix onnx.Pad constant

### DIFF
--- a/lib/Conversion/TorchOnnxToTorch/DefaultDomainGtoP.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/DefaultDomainGtoP.cpp
@@ -970,17 +970,8 @@ void mlir::torch::onnx_c::populateDefaultDomainGtoP(
         }
 
         if (!constantValue) {
-          auto dataTensorType = data.getType().cast<Torch::ValueTensorType>();
-          if (dataTensorType.getDtype().isa<IntegerType>())
-            constantValue = rewriter.create<Torch::ConstantIntOp>(
-                loc, rewriter.getI64IntegerAttr(0));
-          if (dataTensorType.getDtype().isa<FloatType>())
-            constantValue = rewriter.create<Torch::ConstantFloatOp>(
-                loc, rewriter.getF64FloatAttr(0.0f));
-
-          if (!constantValue)
-            return rewriter.notifyMatchFailure(
-                binder.op, "expected integer or float data tensor");
+          constantValue = rewriter.create<Torch::ConstantFloatOp>(
+              loc, rewriter.getF64FloatAttr(0.0f));
         }
 
         // Extract all the values of 1-D pad tensor and create a list of all


### PR DESCRIPTION
Looking at the `GeneratedTorchOps.td`. This leaves two options, either the operator specification is wrong or the code generating it.

I check a bit and it seems that indeed the op spec is right. References:

https://github.com/pytorch/pytorch/blob/543a870943120484db547382ed9ca9538a40f284/torch/csrc/api/include/torch/nn/functional/padding.h#L12

https://pytorch.org/docs/main/generated/torch.nn.functional.pad.html#torch.nn.functional.pad

```
def Torch_AtenPadOp : Torch_Op<"aten.pad", [
    AllowsTypeRefinement,
    HasValueSemantics,
    ReadOnly
  ]> {
  let summary = "Generated op for `aten::pad : (Tensor, int[], str, float?) -> (Tensor)`";
  let arguments = (ins
    AnyTorchTensorType:$self,
    AnyTorchListOfTorchIntType:$pad,
    Torch_StringType:$mode,
    AnyTorchOptionalFloatType:$value
  );
  let results = (outs
    AnyTorchTensorType:$result
  );
  let hasCustomAssemblyFormat = 1;
  let extraClassDefinition = [{
    ParseResult AtenPadOp::parse(OpAsmParser &parser, OperationState &result) {
      return parseDefaultTorchOp(parser, result, 4, 1);
    }
    void AtenPadOp::print(OpAsmPrinter &printer) {
      printDefaultTorchOp(printer, *this, 4, 1);
    }
  }];
}
```