### PR TITLE
Error out if version has the wrong type

### DIFF
--- a/lib/Conversion/TorchOnnxToTorch/Patterns.cpp
+++ b/lib/Conversion/TorchOnnxToTorch/Patterns.cpp
@@ -33,12 +33,8 @@ LogicalResult OnnxCustomOpConversionPattern::matchAndRewrite(
   // overrides the function's domainVersion and will be used for matching later
   // here.
   if (auto attr = op->getAttrOfType<IntegerAttr>("torch.onnx_meta.version")) {
-    if (auto type = dyn_cast<IntegerType>(attr.getType())) {
-      if (type.isSigned()) {
-        opDomainVersion =
-            op->getAttrOfType<IntegerAttr>("torch.onnx_meta.version").getSInt();
-      }
-    }
+    assert(cast<IntegerType>(attr.getType()).isSigned());
+    opDomainVersion = attr.getSInt();
   }
   auto &reggies = foundIt->second;
   for (const HandlerReg &reg : reggies) {


### PR DESCRIPTION
If the version attribute has a wrong type, error out instead of not using it.

Should this be an assertion? Since it is an invariant, I guess a match failure is not what we want.