### PR TITLE
CMakeLists.txt: Fix bad include paths in torch_mlir_target_includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,7 +129,6 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
 
 function(torch_mlir_target_includes target)
   set(_dirs
-    $<BUILD_INTERFACE:${MLIR_INCLUDE_DIRS}>
     $<BUILD_INTERFACE:${TORCH_MLIR_SOURCE_DIR}/include>
     $<BUILD_INTERFACE:${TORCH_MLIR_BINARY_DIR}/include>
   )


### PR DESCRIPTION
The removed code was generating include paths like `-Itorch-mlir/lib/Dialect/TorchConversion/IR/ci/llvm-project/mlir/include` where the intention was to generate
`-Itorch-mlir/lib/Dialect/TorchConversion/IR -I/ci/llvm-project/mlir/include` when running a build in a toplevel directory like `/ci`.

I think this is due to `MLIR_INCLUDE_DIRS` containing two directories, and it seems that together with `$<BUILD_INTERFACE:`, it triggers a bug (?) in cmake where it concatenates the previous and this new path instead of separating them.

We actually don't need to add MLIR_INCLUDE_DIRS here anyways because we already do `include_directories(${MLIR_INCLUDE_DIRS})` above. So this PR just removes it.