### PR TITLE
Disable test for TORCH_MLIR_ENABLE_PYTORCH_EXTENSIONS

### DIFF
--- a/test/python/compile.py
+++ b/test/python/compile.py
@@ -5,6 +5,9 @@ import sys
 import torch
 from torch_mlir import torchscript
 
+# torchscript doesn't exist when TORCH_MLIR_ENABLE_PYTORCH_EXTENSIONS is OFF
+# UNSUPPORTED: true
+
 
 def run_test(f):
     print("TEST:", f.__name__, file=sys.stderr)


### PR DESCRIPTION
We want to build downstream with TORCH_MLIR_ENABLE_PYTORCH_EXTENSIONS=OFF, but test/python/compile.py doesn't work without that flag.