### PR TITLE
Disable sparse_test

### DIFF
--- a/test/python/fx_importer/sparsity/sparse_test.py
+++ b/test/python/fx_importer/sparsity/sparse_test.py
@@ -5,6 +5,9 @@
 
 # RUN: %PYTHON %s | FileCheck %s
 
+# torch_mlir_e2e_test is not available downstream.
+# UNSUPPORTED: true
+
 from typing import Any, Callable, Optional, Tuple, Dict
 
 import torch


### PR DESCRIPTION
sparse_test uses the torch_mlir_e2e_test package, which is not available downstream. We also don't care about sparsity.