### PR TITLE
ci: Use ubuntu-22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         torch-version: [nightly, stable]
     name: Build and Test (Linux, torch-${{ matrix.torch-version }}, assertions)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       CACHE_DIR: ${{ github.workspace }}/.container-cache
     steps:


### PR DESCRIPTION
github changed ubuntu-latest to mean ubuntu-24.04 recently, which breaks our builds which assume python 3.10