### PR TITLE
Move pytorch-requirements.txt to an available version

### DIFF
--- a/pytorch-requirements.txt
+++ b/pytorch-requirements.txt
@@ -3,5 +3,8 @@
 # versions at the same pace. The wheels will therefore be cached on the xilinx
 # release page, and we use this page as an additional source for the wheels.
 -f https://xilinx.github.io/torch-mlir/package-index/
+# Temporarily using stable wheel until we are back at a nightly version that is
+# available.
+--extra-index-url https://download.pytorch.org/whl/cpu
 --pre
-torch==2.7.0.dev20250310
+torch==2.7.0+cpu

--- a/torchvision-requirements.txt
+++ b/torchvision-requirements.txt
@@ -4,4 +4,4 @@
 # release page, and we use this page as an additional source for the wheels.
 -f https://xilinx.github.io/torch-mlir/package-index/
 --pre
-torchvision==0.22.0.dev20250310
+torchvision==0.22.0


### PR DESCRIPTION
The currently reference nightly version is not available on any mirror, which makes CI fail on any PR.